### PR TITLE
Change version of image to 2.0 in deploy-complete.yml

### DIFF
--- a/Deployments/deploy-complete.yml
+++ b/Deployments/deploy-complete.yml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 1
       containers:
       - name: hello-pod
-        image: nigelpoulton/getting-started-k8s:1.0
+        image: nigelpoulton/getting-started-k8s:2.0
         imagePullPolicy: Always
         ports:
         - containerPort: 8080


### PR DESCRIPTION
because this is what is shown in the PS course

I am going through the PS course ATM and noticed that when I apply this file, I don't have a new ReplicaSet created and when I open localhost on the node port I get the old version. Then I noticed that the version in the yaml is `1.0`, while in the file you apply on the course video it is `2.0`

Hope I was helpful and thanks for the great content! ☺️