### PR TITLE
Fix typo in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 Node.js web app for use in Pluralsight [Getting Started with Kubernetes](https://app.pluralsight.com/library/courses/getting-started-kubernetes/table-of-contents) video course.
 
-Packages and dependencies will be upadted annually. May contain vulnerable code, **use at own risk**.
+Packages and dependencies will be updated annually. May contain vulnerable code, **use at own risk**.
 
 ## App
 


### PR DESCRIPTION
Fixing a typo in readme.md
`upadted` -> `updated`