### PR TITLE
Avoid Docker build warning

### DIFF
--- a/App/v1/Dockerfile
+++ b/App/v1/Dockerfile
@@ -12,4 +12,5 @@ RUN cd /src; npm install
 EXPOSE 8080
 
 # Run this command (starts the app) when the container starts
-CMD cd /src && node ./app.js
+WORKDIR /src
+CMD ["node", "./app.js"]


### PR DESCRIPTION
This change is to avoid the following warning when building the Docker container.

```
 1 warning found (use docker --debug to expand):
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 15)
```

https://docs.docker.com/reference/build-checks/json-args-recommended/